### PR TITLE
test combine api responses

### DIFF
--- a/explorations/test_combine.ipynb
+++ b/explorations/test_combine.ipynb
@@ -1,0 +1,512 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_crypto = {'data': {'TRX': [{'circulating_supply': 86094399562.5024,\n",
+    "                   'cmc_rank': 10,\n",
+    "                   'date_added': '2017-09-13T00:00:00.000Z',\n",
+    "                   'id': 1958,\n",
+    "                   'infinite_supply': True,\n",
+    "                   'is_active': 1,\n",
+    "                   'is_fiat': 0,\n",
+    "                   'last_updated': '2025-02-17T13:59:00.000Z',\n",
+    "                   'max_supply': None,\n",
+    "                   'name': 'TRON',\n",
+    "                   'num_market_pairs': 1119,\n",
+    "                   'platform': None,\n",
+    "                   'quote': {'EUR': {'fully_diluted_market_cap': 20233696928.525513,\n",
+    "                                     'last_updated': '2025-02-17T13:58:04.000Z',\n",
+    "                                     'market_cap': 20233689684.600048,\n",
+    "                                     'market_cap_dominance': 0.6595,\n",
+    "                                     'percent_change_1h': -0.41005239,\n",
+    "                                     'percent_change_24h': 2.74550596,\n",
+    "                                     'percent_change_30d': 0.85427889,\n",
+    "                                     'percent_change_60d': -6.73750895,\n",
+    "                                     'percent_change_7d': 3.53201427,\n",
+    "                                     'percent_change_90d': 21.91951073,\n",
+    "                                     'price': 0.23501748995776303,\n",
+    "                                     'tvl': None,\n",
+    "                                     'volume_24h': 583399725.1201158,\n",
+    "                                     'volume_change_24h': 53.2092}},\n",
+    "                   'self_reported_circulating_supply': None,\n",
+    "                   'self_reported_market_cap': None,\n",
+    "                   'slug': 'tron',\n",
+    "                   'symbol': 'TRX',\n",
+    "                   'tags': [{'category': 'INDUSTRY',\n",
+    "                             'name': 'Media',\n",
+    "                             'slug': 'media'},\n",
+    "                            {'category': 'INDUSTRY',\n",
+    "                             'name': 'Payments',\n",
+    "                             'slug': 'payments'},\n",
+    "                            {'category': 'PLATFORM',\n",
+    "                             'name': 'Ethereum Ecosystem',\n",
+    "                             'slug': 'ethereum-ecosystem'},\n",
+    "                            {'category': 'PLATFORM',\n",
+    "                             'name': 'TRON Ecosystem',\n",
+    "                             'slug': 'tron-ecosystem'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': 'Layer 1',\n",
+    "                             'slug': 'layer-1'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': 'DWF Labs Portfolio',\n",
+    "                             'slug': 'dwf-labs-portfolio'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': 'Alleged SEC Securities',\n",
+    "                             'slug': 'alleged-sec-securities'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': '2017/18 Alt season',\n",
+    "                             'slug': '2017-2018-alt-season'},\n",
+    "                            {'category': 'PLATFORM',\n",
+    "                             'name': 'Tron20 Ecosystem',\n",
+    "                             'slug': 'tron20-ecosystem'}],\n",
+    "                   'total_supply': 86094430385.43498,\n",
+    "                   'tvl_ratio': None}],\n",
+    "          'XRP': [{'circulating_supply': 57818864895,\n",
+    "                   'cmc_rank': 3,\n",
+    "                   'date_added': '2013-08-04T00:00:00.000Z',\n",
+    "                   'id': 52,\n",
+    "                   'infinite_supply': False,\n",
+    "                   'is_active': 1,\n",
+    "                   'is_fiat': 0,\n",
+    "                   'last_updated': '2025-02-17T13:59:00.000Z',\n",
+    "                   'max_supply': 100000000000,\n",
+    "                   'name': 'XRP',\n",
+    "                   'num_market_pairs': 1534,\n",
+    "                   'platform': None,\n",
+    "                   'quote': {'EUR': {'fully_diluted_market_cap': 255954176601.42966,\n",
+    "                                     'last_updated': '2025-02-17T13:58:04.000Z',\n",
+    "                                     'market_cap': 147989799562.29288,\n",
+    "                                     'market_cap_dominance': 4.8238,\n",
+    "                                     'percent_change_1h': -0.47757384,\n",
+    "                                     'percent_change_24h': -1.89119571,\n",
+    "                                     'percent_change_30d': -17.13736563,\n",
+    "                                     'percent_change_60d': 13.15625438,\n",
+    "                                     'percent_change_7d': 8.71884754,\n",
+    "                                     'percent_change_90d': 147.68499157,\n",
+    "                                     'price': 2.559541766014341,\n",
+    "                                     'tvl': None,\n",
+    "                                     'volume_24h': 4084788884.458038,\n",
+    "                                     'volume_change_24h': 19.4476}},\n",
+    "                   'self_reported_circulating_supply': None,\n",
+    "                   'self_reported_market_cap': None,\n",
+    "                   'slug': 'xrp',\n",
+    "                   'symbol': 'XRP',\n",
+    "                   'tags': [{'category': 'INDUSTRY',\n",
+    "                             'name': 'Medium of Exchange',\n",
+    "                             'slug': 'medium-of-exchange'},\n",
+    "                            {'category': 'INDUSTRY',\n",
+    "                             'name': 'Enterprise Solutions',\n",
+    "                             'slug': 'enterprise-solutions'},\n",
+    "                            {'category': 'PLATFORM',\n",
+    "                             'name': 'XRP Ecosystem',\n",
+    "                             'slug': 'xrp-ecosystem'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': 'Arrington XRP Capital Portfolio',\n",
+    "                             'slug': 'arrington-xrp-capital-portfolio'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': 'Galaxy Digital Portfolio',\n",
+    "                             'slug': 'galaxy-digital-portfolio'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': 'a16z Portfolio',\n",
+    "                             'slug': 'a16z-portfolio'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': 'Pantera Capital Portfolio',\n",
+    "                             'slug': 'pantera-capital-portfolio'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': 'FTX Bankruptcy Estate ',\n",
+    "                             'slug': 'ftx-bankruptcy-estate'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': '2017/18 Alt season',\n",
+    "                             'slug': '2017-2018-alt-season'},\n",
+    "                            {'category': 'PLATFORM',\n",
+    "                             'name': 'Klaytn Ecosystem',\n",
+    "                             'slug': 'klaytn-ecosystem'},\n",
+    "                            {'category': 'CATEGORY',\n",
+    "                             'name': 'Made in America',\n",
+    "                             'slug': 'made-in-america'}],\n",
+    "                   'total_supply': 99986451428,\n",
+    "                   'tvl_ratio': None},\n",
+    "                  {'circulating_supply': 81597517,\n",
+    "                   'cmc_rank': 2264,\n",
+    "                   'date_added': '2023-08-11T16:17:34.000Z',\n",
+    "                   'id': 27809,\n",
+    "                   'infinite_supply': False,\n",
+    "                   'is_active': 1,\n",
+    "                   'is_fiat': 0,\n",
+    "                   'last_updated': '2025-02-17T13:59:00.000Z',\n",
+    "                   'max_supply': None,\n",
+    "                   'name': 'HarryPotterObamaPacMan8Inu',\n",
+    "                   'num_market_pairs': 12,\n",
+    "                   'platform': {'id': 1027,\n",
+    "                                'name': 'Ethereum',\n",
+    "                                'slug': 'ethereum',\n",
+    "                                'symbol': 'ETH',\n",
+    "                                'token_address': '0x07E0EDf8ce600FB51d44F51E3348D77D67F298ae'},\n",
+    "                   'quote': {'EUR': {'fully_diluted_market_cap': 443790.26148899907,\n",
+    "                                     'last_updated': '2025-02-17T13:58:04.000Z',\n",
+    "                                     'market_cap': 442724.04278152494,\n",
+    "                                     'market_cap_dominance': 0,\n",
+    "                                     'percent_change_1h': 4.09656909,\n",
+    "                                     'percent_change_24h': 4.33019253,\n",
+    "                                     'percent_change_30d': -58.69220033,\n",
+    "                                     'percent_change_60d': -58.13208025,\n",
+    "                                     'percent_change_7d': 9.34142503,\n",
+    "                                     'percent_change_90d': -56.02998758,\n",
+    "                                     'price': 0.005425704838316648,\n",
+    "                                     'tvl': None,\n",
+    "                                     'volume_24h': 1359.551321563383,\n",
+    "                                     'volume_change_24h': -59.3349}},\n",
+    "                   'self_reported_circulating_supply': None,\n",
+    "                   'self_reported_market_cap': None,\n",
+    "                   'slug': 'harrypotterobamapacman8inu',\n",
+    "                   'symbol': 'XRP',\n",
+    "                   'tags': [{'category': 'INDUSTRY',\n",
+    "                             'name': 'Memes',\n",
+    "                             'slug': 'memes'},\n",
+    "                            {'category': 'PLATFORM',\n",
+    "                             'name': 'Ethereum Ecosystem',\n",
+    "                             'name': 'Ethereum Ecosystem',\n",
+    "                             'slug': 'ethereum-ecosystem'}],\n",
+    "                   'total_supply': 81794028.70369202,\n",
+    "                   'tvl_ratio': None}]},\n",
+    " 'status': {'credit_count': 1,\n",
+    "            'elapsed': 23,\n",
+    "            'error_code': 0,\n",
+    "            'error_message': None,\n",
+    "            'notice': None,\n",
+    "            'timestamp': '2025-02-17T14:00:19.460Z'}}\n",
+    "            "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(dict, 2)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(data_crypto), len(data_crypto)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(data_crypto[\"data\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(data_crypto[\"status\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(dict, dict_keys(['TRX', 'XRP']))"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(data_crypto[\"data\"]), data_crypto[\"data\"].keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(list, 1)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(data_crypto[\"data\"][\"TRX\"]), len(data_crypto[\"data\"][\"TRX\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(data_crypto[\"data\"][\"TRX\"][0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['circulating_supply',\n",
+       " 'cmc_rank',\n",
+       " 'date_added',\n",
+       " 'id',\n",
+       " 'last_updated',\n",
+       " 'max_supply',\n",
+       " 'name',\n",
+       " 'quote',\n",
+       " 'slug',\n",
+       " 'symbol',\n",
+       " 'total_supply']"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "crypto_keys = list(data_crypto[\"data\"][\"TRX\"][0].keys())\n",
+    "\n",
+    "selected_crypto_keys = {\n",
+    "    'circulating_supply': 'The number of coins currently in circulation.',\n",
+    "    'cmc_rank': 'Cryptocurrencies rank based on market capitalization on CoinMarketCap',\n",
+    "    'date_added' : 'The date cryptocurrency was added to CoinMarketCap',\n",
+    "    'id': 'Unique identifier for cryprocurrency on CoinMarketCap',\n",
+    "    'last_updated': 'The last time this data was updated (UTC timestamp)',\n",
+    "    'max_supply': 'Maximum possible supply of the cryptocurrency (None = no fixed limit).',\n",
+    "    'name': 'The full name of the cryptocurrency ',\n",
+    "    'quote': 'Price and market data for cryptocurrency',\n",
+    "    'slug': 'A URL-friendly, unique identifier for the cryptocurrency.',\n",
+    "    'symbol': 'The abbreviated symbol for the cryptocurrency used on exchanges and in trading.',\n",
+    "    'total_supply': 'The total number of coins or tokens that have been created (minted) for that cryptocurrency, minus any coins that have been burned.',\n",
+    "}\n",
+    "\n",
+    "selected_crypto_keys_list = list(selected_crypto_keys.keys())\n",
+    "selected_crypto_keys_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SYMBOLS_list = ['XRP', 'TRX']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_exchange = {\n",
+    "    \"date\": [\"2025-02-17\"],\n",
+    "    \"timestamp\": [1739789055],\n",
+    "    \"base\": [\"EUR\"],\n",
+    "    \"DKK\": [7.459962],\n",
+    "    \"NOK\": [11.652164],\n",
+    "    \"SEK\": [11.231903]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_data = {\n",
+    " SYMBOLS_list[0] : {symbol: data_crypto[\"data\"][SYMBOLS_list[0]][0].get(symbol) for symbol in selected_crypto_keys_list},\n",
+    " SYMBOLS_list[1] : {symbol: data_crypto[\"data\"][SYMBOLS_list[1]][0].get(symbol) for symbol in selected_crypto_keys_list},\n",
+    " 'data_exchange' : data_exchange\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'XRP': {'circulating_supply': 57818864895,\n",
+       "  'cmc_rank': 3,\n",
+       "  'date_added': '2013-08-04T00:00:00.000Z',\n",
+       "  'id': 52,\n",
+       "  'last_updated': '2025-02-17T13:59:00.000Z',\n",
+       "  'max_supply': 100000000000,\n",
+       "  'name': 'XRP',\n",
+       "  'quote': {'EUR': {'fully_diluted_market_cap': 255954176601.42966,\n",
+       "    'last_updated': '2025-02-17T13:58:04.000Z',\n",
+       "    'market_cap': 147989799562.29288,\n",
+       "    'market_cap_dominance': 4.8238,\n",
+       "    'percent_change_1h': -0.47757384,\n",
+       "    'percent_change_24h': -1.89119571,\n",
+       "    'percent_change_30d': -17.13736563,\n",
+       "    'percent_change_60d': 13.15625438,\n",
+       "    'percent_change_7d': 8.71884754,\n",
+       "    'percent_change_90d': 147.68499157,\n",
+       "    'price': 2.559541766014341,\n",
+       "    'tvl': None,\n",
+       "    'volume_24h': 4084788884.458038,\n",
+       "    'volume_change_24h': 19.4476}},\n",
+       "  'slug': 'xrp',\n",
+       "  'symbol': 'XRP',\n",
+       "  'total_supply': 99986451428},\n",
+       " 'TRX': {'circulating_supply': 86094399562.5024,\n",
+       "  'cmc_rank': 10,\n",
+       "  'date_added': '2017-09-13T00:00:00.000Z',\n",
+       "  'id': 1958,\n",
+       "  'last_updated': '2025-02-17T13:59:00.000Z',\n",
+       "  'max_supply': None,\n",
+       "  'name': 'TRON',\n",
+       "  'quote': {'EUR': {'fully_diluted_market_cap': 20233696928.525513,\n",
+       "    'last_updated': '2025-02-17T13:58:04.000Z',\n",
+       "    'market_cap': 20233689684.600048,\n",
+       "    'market_cap_dominance': 0.6595,\n",
+       "    'percent_change_1h': -0.41005239,\n",
+       "    'percent_change_24h': 2.74550596,\n",
+       "    'percent_change_30d': 0.85427889,\n",
+       "    'percent_change_60d': -6.73750895,\n",
+       "    'percent_change_7d': 3.53201427,\n",
+       "    'percent_change_90d': 21.91951073,\n",
+       "    'price': 0.23501748995776303,\n",
+       "    'tvl': None,\n",
+       "    'volume_24h': 583399725.1201158,\n",
+       "    'volume_change_24h': 53.2092}},\n",
+       "  'slug': 'tron',\n",
+       "  'symbol': 'TRX',\n",
+       "  'total_supply': 86094430385.43498},\n",
+       " 'data_exchange': {'date': ['2025-02-17'],\n",
+       "  'timestamp': [1739789055],\n",
+       "  'base': ['EUR'],\n",
+       "  'DKK': [7.459962],\n",
+       "  'NOK': [11.652164],\n",
+       "  'SEK': [11.231903]}}"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "combined_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compare dates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TRUE\n"
+     ]
+    }
+   ],
+   "source": [
+    "if data_crypto[\"data\"][\"TRX\"][0][\"last_updated\"][0:10] == data_exchange[\"date\"][0]:\n",
+    "    print(\"TRUE\")\n",
+    "else: \n",
+    "    print(\"NOT TRUE\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Questions to discuss:
- do we want to separate currency data into separate dictionaries for each crypto + exchange rates, to prepare to have 2 producers and 2 consumers, each for one currency
- OR do we want to keep all information together, have one producer, one consumer, BUT split data to two separate tables when we send it to postgres
- OR keep the data together even in postgtes ??